### PR TITLE
Enable global CORS support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  app.enableCors();
+  const app = await NestFactory.create(AppModule, { cors: true });
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- enable CORS across the entire API by setting the `cors` flag during Nest app creation

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684c7824cc00832795be806d8383843e