### PR TITLE
Harden API security: Auth0 JWT auth, locked CORS, validation, rate li…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# ---- MongoDB ----
+# Full connection string INCLUDING credentials. Never commit the real value.
+# (The old hard-coded Admin:admin credentials are compromised and must be rotated.)
+MONGODB_URI=mongodb+srv://<user>:<password>@<cluster>.mongodb.net/?retryWrites=true&w=majority
+MONGODB_DB=ContentCalender
+
+# ---- Auth0 (JWT validation) ----
+# Your Auth0 tenant domain, e.g. dev-sipsml8vb00v5eww.us.auth0.com
+AUTH0_DOMAIN=dev-sipsml8vb00v5eww.us.auth0.com
+# The Identifier (audience) of the Auth0 API you created for this backend,
+# e.g. https://api.film-enthusiast
+AUTH0_AUDIENCE=https://api.film-enthusiast
+
+# ---- CORS ----
+# Comma-separated list of allowed front-end origins (no wildcard).
+# Example: https://your-frontend.example.com,http://localhost:4200
+CORS_ORIGINS=http://localhost:4200
+
+# ---- Server ----
+# Render sets PORT automatically; defaults to 3000 locally.
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -24,12 +24,42 @@
 
 ## Description
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+REST API (NestJS + MongoDB) backing the Film Enthusiast SPA.
+
+## Security & configuration
+
+All configuration comes from environment variables — **no secrets are committed**.
+Copy `.env.example` to `.env` and fill it in:
+
+| Variable | Purpose |
+|---|---|
+| `MONGODB_URI` | MongoDB connection string (includes credentials) |
+| `MONGODB_DB` | Database name (default `ContentCalender`) |
+| `AUTH0_DOMAIN` | Auth0 tenant domain, e.g. `dev-...us.auth0.com` |
+| `AUTH0_AUDIENCE` | Identifier of the Auth0 API created for this backend |
+| `CORS_ORIGINS` | Comma-separated allowed front-end origins (no wildcard) |
+| `PORT` | Listen port (Render sets this automatically) |
+
+What is enforced:
+
+- **Auth0 JWT validation** on every route (RS256 via the tenant JWKS, with
+  `iss` / `aud` / `exp` checked). Missing/invalid token → **401**. Only the
+  `GET /` health route is `@Public()`.
+- **CORS** restricted to `CORS_ORIGINS` (the app fails closed if it is unset).
+- **Body validation** via a global `ValidationPipe` + DTOs on `POST`/`PUT /movies`
+  (unknown fields stripped, so NoSQL-operator payloads can't reach Mongo).
+- **Rate limiting** at 100 requests/minute per IP.
+
+> Ops follow-ups that can't be done in code: **rotate the MongoDB credentials**
+> (the old `Admin:admin` pair was committed to git history and is compromised),
+> rotate the RapidAPI key, create the Auth0 API to obtain `AUTH0_AUDIENCE`, and
+> purge the secrets from git history (BFG / git-filter-repo).
 
 ## Installation
 
 ```bash
 $ npm install
+$ cp .env.example .env   # then fill in the values
 ```
 
 ## Running the app

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,14 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^10.2.7",
+        "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^10.2.7",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/throttler": "^6.5.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.15.1",
+        "jsonwebtoken": "^9.0.3",
+        "jwks-rsa": "^4.0.1",
         "mongodb": "^6.1.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1"
@@ -22,6 +28,7 @@
         "@nestjs/testing": "^10.0.0",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.3.1",
         "@types/supertest": "^2.0.12",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
@@ -1500,6 +1507,20 @@
         }
       }
     },
+    "node_modules/@nestjs/config": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.4.tgz",
+      "integrity": "sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==",
+      "dependencies": {
+        "dotenv": "17.4.1",
+        "dotenv-expand": "12.0.3",
+        "lodash": "4.18.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "10.2.7",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.2.7.tgz",
@@ -1654,6 +1675,16 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1947,11 +1978,25 @@
       "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
       "dev": true
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
       "integrity": "sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==",
       "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
       "version": "20.8.4",
@@ -2030,6 +2075,11 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA=="
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.1",
@@ -2952,6 +3002,11 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3127,6 +3182,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
+      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
+      "dependencies": {
+        "@types/validator": "^13.15.3",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.15.22"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -3438,7 +3508,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3733,6 +3802,50 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -5763,6 +5876,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5847,6 +5968,61 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-4.0.1.tgz",
+      "integrity": "sha512-poXwUA8S4cP9P5N8tZS3xnUDJH8WmwSGfKK9gIaRPdjLHyJtd9iX/cngX9CUIe0Caof5JhK2EbN7N5lnnaf9NA==",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^6.1.3",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^3.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5887,6 +6063,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.5.tgz",
+      "integrity": "sha512-7/kRezHmQlMfO6pmvt34orO/g3j1C47k8FCBXFgj/mklTLwQdBca1LkhDK6RM8UyM6JqHFAIikMdkKkyfQy39A=="
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -5918,10 +6104,44 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -5934,6 +6154,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -5958,6 +6183,23 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-3.0.0.tgz",
+      "integrity": "sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "^11.0.1"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/macos-release": {
@@ -6247,8 +6489,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multer": {
       "version": "1.4.4-lts.1",
@@ -7295,7 +7536,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7310,7 +7550,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -7321,8 +7560,7 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -8250,6 +8488,14 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,14 @@
   },
   "dependencies": {
     "@nestjs/common": "^10.2.7",
+    "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^10.2.7",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/throttler": "^6.5.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.15.1",
+    "jsonwebtoken": "^9.0.3",
+    "jwks-rsa": "^4.0.1",
     "mongodb": "^6.1.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"
@@ -33,6 +39,7 @@
     "@nestjs/testing": "^10.0.0",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.3.1",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
@@ -58,6 +65,9 @@
     ],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { Public } from './auth/public.decorator';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
+  @Public()
   @Get()
   getHello(): string {
     return this.appService.getHello();

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,11 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { APP_GUARD } from '@nestjs/core';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { JwtAuthGuard } from './auth/jwt-auth.guard';
+import { DatabaseModule } from './database/database.module';
 import { MovieService } from './movie/movie.service';
 import { MoviesController } from './movies/movies.controller';
 import { CastCrewService } from './cast-crew/cast-crew.service';
@@ -9,8 +14,21 @@ import { AwardsService } from './awards/awards.service';
 import { AwardsController } from './awards/awards.controller';
 
 @Module({
-  imports: [],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    DatabaseModule,
+    // Public API: cap each client IP to 100 requests/minute.
+    ThrottlerModule.forRoot([{ ttl: 60000, limit: 100 }]),
+  ],
   controllers: [AppController, MoviesController, CastCrewController, AwardsController],
-  providers: [AppService, MovieService, CastCrewService, AwardsService],
+  providers: [
+    AppService,
+    MovieService,
+    CastCrewService,
+    AwardsService,
+    // Order matters: rate-limit first, then authenticate.
+    { provide: APP_GUARD, useClass: ThrottlerGuard },
+    { provide: APP_GUARD, useClass: JwtAuthGuard },
+  ],
 })
 export class AppModule {}

--- a/src/app.security.spec.ts
+++ b/src/app.security.spec.ts
@@ -1,0 +1,57 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+
+// jwks-rsa -> jose is ESM-only and can't be transformed by ts-jest.
+jest.mock('jwks-rsa', () => ({
+  JwksClient: jest.fn().mockImplementation(() => ({
+    getSigningKey: jest.fn(),
+  })),
+}));
+
+// Auth0 config the guard needs at construction time.
+process.env.AUTH0_DOMAIN = 'tenant.us.auth0.com';
+process.env.AUTH0_AUDIENCE = 'https://api.film-enthusiast';
+process.env.MONGODB_URI = 'mongodb://localhost:27017';
+
+import { AppModule } from './app.module';
+import { DatabaseService } from './database/database.service';
+
+describe('API security (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      // Avoid any real MongoDB connection.
+      .overrideProvider(DatabaseService)
+      .useValue({
+        collection: () => ({ find: () => ({ toArray: async () => [] }) }),
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it('allows the public health route without a token', async () => {
+    await request(app.getHttpServer()).get('/').expect(200);
+  });
+
+  it('rejects GET /movies without a token (401)', async () => {
+    await request(app.getHttpServer()).get('/movies').expect(401);
+  });
+
+  it('rejects POST /movies without a token (401)', async () => {
+    await request(app.getHttpServer()).post('/movies').send({}).expect(401);
+  });
+
+  it('rejects GET /awards without a token (401)', async () => {
+    await request(app.getHttpServer()).get('/awards').expect(401);
+  });
+});

--- a/src/auth/jwt-auth.guard.spec.ts
+++ b/src/auth/jwt-auth.guard.spec.ts
@@ -1,0 +1,71 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Reflector } from '@nestjs/core';
+
+// jwks-rsa pulls in the ESM-only `jose` package, which ts-jest can't transform.
+// We don't reach JWKS fetching in these tests, so stub the client.
+jest.mock('jwks-rsa', () => ({
+  JwksClient: jest.fn().mockImplementation(() => ({
+    getSigningKey: jest.fn(),
+  })),
+}));
+
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+function makeContext(
+  headers: Record<string, string> = {},
+): ExecutionContext {
+  const request = { headers };
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+    getHandler: () => undefined,
+    getClass: () => undefined,
+  } as unknown as ExecutionContext;
+}
+
+function makeGuard(reflector: Reflector): JwtAuthGuard {
+  const config = {
+    get: (key: string) =>
+      key === 'AUTH0_DOMAIN'
+        ? 'tenant.us.auth0.com'
+        : key === 'AUTH0_AUDIENCE'
+          ? 'https://api.film-enthusiast'
+          : undefined,
+  } as unknown as ConfigService;
+  return new JwtAuthGuard(reflector, config);
+}
+
+describe('JwtAuthGuard', () => {
+  it('throws when AUTH0 config is missing', () => {
+    const config = { get: () => undefined } as unknown as ConfigService;
+    expect(() => new JwtAuthGuard(new Reflector(), config)).toThrow();
+  });
+
+  it('allows @Public() routes without a token', async () => {
+    const reflector = {
+      getAllAndOverride: () => true,
+    } as unknown as Reflector;
+    const guard = makeGuard(reflector);
+    await expect(guard.canActivate(makeContext())).resolves.toBe(true);
+  });
+
+  it('rejects protected routes with no bearer token', async () => {
+    const reflector = {
+      getAllAndOverride: () => false,
+    } as unknown as Reflector;
+    const guard = makeGuard(reflector);
+    await expect(guard.canActivate(makeContext())).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects a malformed (non-bearer) authorization header', async () => {
+    const reflector = {
+      getAllAndOverride: () => false,
+    } as unknown as Reflector;
+    const guard = makeGuard(reflector);
+    await expect(
+      guard.canActivate(makeContext({ authorization: 'Basic abc123' })),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+});

--- a/src/auth/jwt-auth.guard.ts
+++ b/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,121 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import {
+  GetPublicKeyOrSecret,
+  JwtPayload,
+  verify,
+  VerifyOptions,
+} from 'jsonwebtoken';
+import { JwksClient } from 'jwks-rsa';
+import { IS_PUBLIC_KEY } from './public.decorator';
+
+/**
+ * Validates Auth0-issued access tokens (RS256) on every request.
+ *
+ * - Signature is verified against the tenant's JWKS endpoint.
+ * - issuer, audience and expiry are all enforced.
+ * - Routes marked with @Public() bypass the check.
+ */
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  private readonly logger = new Logger(JwtAuthGuard.name);
+  private readonly issuer: string;
+  private readonly audience: string;
+  private readonly jwks: JwksClient;
+
+  constructor(
+    private readonly reflector: Reflector,
+    config: ConfigService,
+  ) {
+    const domain = config.get<string>('AUTH0_DOMAIN');
+    const audience = config.get<string>('AUTH0_AUDIENCE');
+    if (!domain || !audience) {
+      throw new Error(
+        'AUTH0_DOMAIN and AUTH0_AUDIENCE must be set to enable JWT validation.',
+      );
+    }
+    // Normalise to the canonical Auth0 issuer form (https://<domain>/).
+    this.issuer = `https://${domain.replace(/^https?:\/\//, '').replace(/\/$/, '')}/`;
+    this.audience = audience;
+    this.jwks = new JwksClient({
+      jwksUri: `${this.issuer}.well-known/jwks.json`,
+      cache: true,
+      rateLimit: true,
+      jwksRequestsPerMinute: 10,
+    });
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const token = this.extractBearerToken(request);
+    if (!token) {
+      throw new UnauthorizedException('Missing bearer token');
+    }
+
+    try {
+      const payload = await this.verifyToken(token);
+      // Attach the verified claims for downstream use (e.g. payload.sub).
+      (request as Request & { user?: JwtPayload }).user = payload;
+      return true;
+    } catch (error) {
+      this.logger.warn(`Rejected token: ${(error as Error).message}`);
+      throw new UnauthorizedException('Invalid or expired token');
+    }
+  }
+
+  private extractBearerToken(request: Request): string | null {
+    const header = request.headers.authorization;
+    if (!header) {
+      return null;
+    }
+    const [scheme, value] = header.split(' ');
+    if (scheme?.toLowerCase() !== 'bearer' || !value) {
+      return null;
+    }
+    return value;
+  }
+
+  private verifyToken(token: string): Promise<JwtPayload> {
+    const getKey: GetPublicKeyOrSecret = (header, callback) => {
+      this.jwks.getSigningKey(header.kid, (err, key) => {
+        if (err || !key) {
+          callback(err ?? new Error('Signing key not found'));
+          return;
+        }
+        callback(null, key.getPublicKey());
+      });
+    };
+
+    const options: VerifyOptions = {
+      algorithms: ['RS256'],
+      issuer: this.issuer,
+      audience: this.audience,
+    };
+
+    return new Promise<JwtPayload>((resolve, reject) => {
+      verify(token, getKey, options, (err, decoded) => {
+        if (err || !decoded || typeof decoded === 'string') {
+          reject(err ?? new Error('Invalid token payload'));
+          return;
+        }
+        resolve(decoded);
+      });
+    });
+  }
+}

--- a/src/auth/public.decorator.ts
+++ b/src/auth/public.decorator.ts
@@ -1,0 +1,9 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+
+/**
+ * Marks a route (or whole controller) as not requiring authentication.
+ * Everything else is protected by the global JwtAuthGuard.
+ */
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/awards/awards.controller.ts
+++ b/src/awards/awards.controller.ts
@@ -1,30 +1,9 @@
-import {
-  Body,
-  Controller,
-  Delete,
-  Get,
-  Header,
-  HttpException,
-  HttpStatus,
-  Options,
-  Param,
-  ParseIntPipe,
-  Post,
-  Put,
-} from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { AwardsService } from './awards.service';
 
 @Controller('awards')
 export class AwardsController {
   constructor(private service: AwardsService) {}
-
-  @Options()
-  @Header('Access-Control-Allow-Origin', '*')
-  @Header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE')
-  @Header('Access-Control-Allow-Headers', 'Content-Type')
-  public options() {
-    return {};
-  }
 
   @Get()
   public getAwards() {

--- a/src/awards/awards.service.ts
+++ b/src/awards/awards.service.ts
@@ -1,31 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import { MongoClient } from 'mongodb';
 import { Award } from 'src/type';
-import { ObjectId } from 'mongodb';
-
-const url =
-  'mongodb+srv://Admin:admin@webframeworkscluster.0dkna9w.mongodb.net/test';
+import { DatabaseService } from 'src/database/database.service';
 
 @Injectable()
 export class AwardsService {
-  private client = new MongoClient(url);
-
-  constructor() {}
-
-  onModuleInit() {
-    this.client.connect();
-  }
-
-  onModuleDestroy() {
-    this.client.close();
-  }
+  constructor(private readonly db: DatabaseService) {}
 
   public async getAwards() {
-    let awards = await this.client
-      .db('ContentCalender')
-      .collection('awards')
-      .find<Award>({})
-      .toArray();
-    return awards;
+    return this.db.collection<Award>('awards').find({}).toArray();
   }
 }

--- a/src/cast-crew/cast-crew.controller.ts
+++ b/src/cast-crew/cast-crew.controller.ts
@@ -1,30 +1,9 @@
-import {
-  Body,
-  Controller,
-  Delete,
-  Get,
-  Header,
-  HttpException,
-  HttpStatus,
-  Options,
-  Param,
-  ParseIntPipe,
-  Post,
-  Put,
-} from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { CastCrewService } from './cast-crew.service';
 
 @Controller('cast-crew')
 export class CastCrewController {
   constructor(private service: CastCrewService) {}
-
-  @Options()
-  @Header('Access-Control-Allow-Origin', '*')
-  @Header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE')
-  @Header('Access-Control-Allow-Headers', 'Content-Type')
-  public options() {
-    return {};
-  }
 
   @Get('/actors')
   public async getAllActors() {

--- a/src/cast-crew/cast-crew.service.ts
+++ b/src/cast-crew/cast-crew.service.ts
@@ -1,60 +1,27 @@
 import { Injectable } from '@nestjs/common';
-import { MongoClient } from 'mongodb';
-import { ObjectId } from 'mongodb';
-
-const url =
-  'mongodb+srv://Admin:admin@webframeworkscluster.0dkna9w.mongodb.net/test';
+import { DatabaseService } from 'src/database/database.service';
 
 @Injectable()
 export class CastCrewService {
-  private client = new MongoClient(url);
-
-  constructor() {}
-
-  onModuleInit() {
-    this.client.connect();
-  }
-
-  onModuleDestroy() {
-    this.client.close();
-  }
+  constructor(private readonly db: DatabaseService) {}
 
   //get actors from db
   public async getAllActors() {
-    let actor = await this.client
-      .db('ContentCalender')
-      .collection('actors')
-      .find({})
-      .toArray();
-    return actor;
+    return this.db.collection('actors').find({}).toArray();
   }
+
   //get actresses from db
   public async getAllActresses() {
-    let actress = await this.client
-      .db('ContentCalender')
-      .collection('actresses')
-      .find({})
-      .toArray();
-    return actress;
+    return this.db.collection('actresses').find({}).toArray();
   }
 
   //get directors from db
   public async getAllDirectors() {
-    let director = await this.client
-      .db('ContentCalender')
-      .collection('directors')
-      .find({})
-      .toArray();
-    return director;
+    return this.db.collection('directors').find({}).toArray();
   }
 
   //get composers from db
   public async getAllComposers() {
-    let composer = await this.client
-      .db('ContentCalender')
-      .collection('composers')
-      .find({})
-      .toArray();
-    return composer;
+    return this.db.collection('composers').find({}).toArray();
   }
 }

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from '@nestjs/common';
+import { DatabaseService } from './database.service';
+
+/**
+ * Global so every feature module shares the one MongoClient
+ * instead of each service opening its own connection pool.
+ */
+@Global()
+@Module({
+  providers: [DatabaseService],
+  exports: [DatabaseService],
+})
+export class DatabaseModule {}

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -1,0 +1,46 @@
+import {
+  Injectable,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Collection, Db, Document, MongoClient } from 'mongodb';
+
+/**
+ * Owns a single shared MongoClient for the whole app.
+ *
+ * The connection string (which includes credentials) is read from the
+ * MONGODB_URI environment variable. It must never be hard-coded in source.
+ */
+@Injectable()
+export class DatabaseService implements OnModuleInit, OnModuleDestroy {
+  private readonly client: MongoClient;
+  private readonly dbName: string;
+
+  constructor(config: ConfigService) {
+    const uri = config.get<string>('MONGODB_URI');
+    if (!uri) {
+      throw new Error(
+        'MONGODB_URI is not set. Provide the MongoDB connection string via environment variable.',
+      );
+    }
+    this.dbName = config.get<string>('MONGODB_DB') ?? 'ContentCalender';
+    this.client = new MongoClient(uri);
+  }
+
+  async onModuleInit(): Promise<void> {
+    await this.client.connect();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.client.close();
+  }
+
+  db(): Db {
+    return this.client.db(this.dbName);
+  }
+
+  collection<T extends Document = Document>(name: string): Collection<T> {
+    return this.db().collection<T>(name);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,35 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
+function parseOrigins(raw?: string): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, { cors: true });
-  await app.listen(3000);
+  const app = await NestFactory.create(AppModule);
+
+  // Restrict CORS to explicitly allowed origins (no wildcard).
+  const allowedOrigins = parseOrigins(process.env.CORS_ORIGINS);
+  app.enableCors({
+    origin: allowedOrigins.length > 0 ? allowedOrigins : false,
+    methods: ['GET', 'POST', 'PUT', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+  });
+
+  // Reject unknown body fields and coerce/validate declared ones.
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      transform: true,
+    }),
+  );
+
+  const port = process.env.PORT ?? 3000;
+  await app.listen(port);
 }
 bootstrap();

--- a/src/movie/movie.service.ts
+++ b/src/movie/movie.service.ts
@@ -1,91 +1,66 @@
 import { Injectable } from '@nestjs/common';
-import { MongoClient } from 'mongodb';
-import { IFilm } from 'src/type';
 import { ObjectId } from 'mongodb';
-
-const url =
-  'mongodb+srv://Admin:admin@webframeworkscluster.0dkna9w.mongodb.net/test';
+import { IFilm } from 'src/type';
+import { DatabaseService } from 'src/database/database.service';
+import { CreateMovieDto } from 'src/movies/dto/create-movie.dto';
+import { UpdateMovieDto } from 'src/movies/dto/update-movie.dto';
 
 @Injectable()
 export class MovieService {
-  private client = new MongoClient(url);
+  constructor(private readonly db: DatabaseService) {}
 
-  constructor() {}
-
-  onModuleInit() {
-    this.client.connect();
+  private movies() {
+    return this.db.collection<IFilm>('movies');
   }
 
-  onModuleDestroy() {
-    this.client.close();
-  }
   public async getMovieById(movieId: string): Promise<IFilm> {
     const objectId = new ObjectId(movieId);
-    const movie = await this.client
-      .db('ContentCalender')
-      .collection('movies')
-      .findOne<IFilm>({ _id: objectId });
-    return movie;
+    return this.movies().findOne({ _id: objectId });
   }
 
   //get movie by name
   public async getMovieByName(movieName: string): Promise<IFilm> {
-    const movie = await this.client
-      .db('ContentCalender')
-      .collection('movies')
-      .findOne<IFilm>({ title: movieName });
-    return movie;
+    return this.movies().findOne({ title: movieName });
   }
 
   public async getAllMovies() {
-    let movie = await this.client
-      .db('ContentCalender')
-      .collection('movies')
-      .find<IFilm>({})
-      .toArray();
-    return movie;
+    return this.movies().find({}).toArray();
   }
 
-  public async addMovie(movie: IFilm) {
+  public async addMovie(movie: CreateMovieDto) {
     // Check for an existing movie with the same title and release_date
-    const existingMovie = await this.client
-      .db('ContentCalender')
-      .collection('movies')
-      .findOne({ title: movie.title, release_date: movie.release_date });
+    const existingMovie = await this.movies().findOne({
+      title: movie.title,
+      release_date: movie.release_date,
+    });
 
     if (existingMovie) {
       throw new Error('Movie already exists');
     }
 
-    const _id = new ObjectId();
-    movie._id = _id;
-    await this.client
-      .db('ContentCalender')
-      .collection('movies')
-      .insertOne(movie);
-    return movie;
+    const document: IFilm = { ...movie, _id: new ObjectId() };
+    await this.movies().insertOne(document);
+    return document;
   }
 
   public async updateMovie(
     movieId: string,
-    updatedMovie: IFilm,
+    updatedMovie: UpdateMovieDto,
   ): Promise<IFilm | null> {
     const objectId = new ObjectId(movieId);
 
-    const existingMovie = await this.client
-      .db('ContentCalender')
-      .collection('movies')
-      .findOne<IFilm>({ _id: objectId });
+    const existingMovie = await this.movies().findOne({ _id: objectId });
     if (!existingMovie) {
       return null; // Movie not found
     }
-    existingMovie.isBookmarked = updatedMovie.isBookmarked;
-    existingMovie.release_date = updatedMovie.release_date;
+    if (updatedMovie.isBookmarked !== undefined) {
+      existingMovie.isBookmarked = updatedMovie.isBookmarked;
+    }
+    if (updatedMovie.release_date !== undefined) {
+      existingMovie.release_date = updatedMovie.release_date;
+    }
     // Perform the update operation
-    await this.client
-      .db('ContentCalender')
-      .collection('movies')
-      .updateOne({ _id: objectId }, { $set: existingMovie });
+    await this.movies().updateOne({ _id: objectId }, { $set: existingMovie });
     return existingMovie;
   }
 }

--- a/src/movies/dto/create-movie.dto.ts
+++ b/src/movies/dto/create-movie.dto.ts
@@ -1,0 +1,63 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+/**
+ * Whitelisted shape for POST /movies. The global ValidationPipe strips any
+ * property not declared here, so arbitrary/object payloads (e.g. NoSQL
+ * operators) can't reach Mongo.
+ */
+export class CreateMovieDto {
+  @IsBoolean()
+  adult: boolean;
+
+  @IsOptional()
+  @IsString()
+  backdrop_path?: string;
+
+  @IsArray()
+  @IsInt({ each: true })
+  genre_ids: number[];
+
+  @IsInt()
+  id: number;
+
+  @IsString()
+  original_language: string;
+
+  @IsString()
+  original_title: string;
+
+  @IsString()
+  overview: string;
+
+  @IsNumber()
+  popularity: number;
+
+  @IsString()
+  poster_path: string;
+
+  @IsString()
+  release_date: string;
+
+  @IsString()
+  title: string;
+
+  @IsBoolean()
+  video: boolean;
+
+  @IsNumber()
+  vote_average: number;
+
+  @IsInt()
+  vote_count: number;
+
+  @IsOptional()
+  @IsBoolean()
+  isBookmarked?: boolean;
+}

--- a/src/movies/dto/update-movie.dto.ts
+++ b/src/movies/dto/update-movie.dto.ts
@@ -1,0 +1,15 @@
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+
+/**
+ * PUT /movies/:id only ever changes the bookmark flag and release date,
+ * so those are the only fields accepted. Everything else is stripped.
+ */
+export class UpdateMovieDto {
+  @IsOptional()
+  @IsBoolean()
+  isBookmarked?: boolean;
+
+  @IsOptional()
+  @IsString()
+  release_date?: string;
+}

--- a/src/movies/movies.controller.ts
+++ b/src/movies/movies.controller.ts
@@ -1,30 +1,27 @@
 import {
+  BadRequestException,
   Body,
   Controller,
-  Delete,
   Get,
-  Header,
   HttpException,
   HttpStatus,
-  Options,
   Param,
-  ParseIntPipe,
   Post,
   Put,
 } from '@nestjs/common';
+import { ObjectId } from 'mongodb';
 import { MovieService } from 'src/movie/movie.service';
-import { IFilm } from 'src/type';
+import { CreateMovieDto } from './dto/create-movie.dto';
+import { UpdateMovieDto } from './dto/update-movie.dto';
 
 @Controller('movies')
 export class MoviesController {
   constructor(private service: MovieService) {}
 
-  @Options()
-  @Header('Access-Control-Allow-Origin', '*')
-  @Header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE')
-  @Header('Access-Control-Allow-Headers', 'Content-Type')
-  public options() {
-    return {};
+  private assertValidId(id: string): void {
+    if (!ObjectId.isValid(id)) {
+      throw new BadRequestException('Invalid movie id');
+    }
   }
 
   @Get()
@@ -34,6 +31,7 @@ export class MoviesController {
 
   @Get(':id')
   public async getMovieById(@Param('id') id: string) {
+    this.assertValidId(id);
     const movie = await this.service.getMovieById(id);
     if (!movie) {
       throw new HttpException('Movie not found', HttpStatus.NOT_FOUND);
@@ -52,7 +50,7 @@ export class MoviesController {
   }
 
   @Post()
-  public async addMovie(@Body() movie: IFilm) {
+  public async addMovie(@Body() movie: CreateMovieDto) {
     try {
       return await this.service.addMovie(movie);
     } catch (error) {
@@ -77,7 +75,11 @@ export class MoviesController {
   }
 
   @Put(':id')
-  public async updateMovie(@Body() movie: IFilm, @Param('id') id: string) {
+  public async updateMovie(
+    @Body() movie: UpdateMovieDto,
+    @Param('id') id: string,
+  ) {
+    this.assertValidId(id);
     return this.service.updateMovie(id, movie);
   }
 }


### PR DESCRIPTION
…miting

- Add Auth0 JWT guard (RS256/JWKS) as a global guard on all routes; @Public() decorator opt-out used only on GET /
- Centralize MongoDB connection in DatabaseService reading MONGODB_URI from env, removing hardcoded Admin:admin credentials from all services
- Lock CORS to CORS_ORIGINS env var (no wildcard); remove manual Access-Control-Allow-Origin: * Options handlers from controllers
- Add global ValidationPipe + CreateMovieDto/UpdateMovieDto to whitelist and strip request body fields (prevents NoSQL-operator injection)
- Add ObjectId validation on :id params (400 instead of 500 on bad input)
- Add rate limiting via @nestjs/throttler (100 req/min per IP)
- Wire @nestjs/config globally; add .env.example documenting all vars
- Add unit + e2e tests proving 401 on protected routes without token
- Fix jest moduleNameMapper for src/ path alias